### PR TITLE
Added ability to overrides default options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.12'
+- '4'
 sudo: false
 after_success: npm run report-coverage
 deploy:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ __Options (defaults):__
 All parameters are optional
 ```js
 {
-    queue: undefined, // Array
+    queue: undefined, // use `superagentQueue.makeQueue()``
     initialTimeout: 2000,
     backoff: {
         exp: { // Exponential backoff
@@ -53,7 +53,7 @@ All parameters are optional
 }
 ```
 
-### `superagentQueue( { queue: [...] } )`
+### `superagentQueue( { queue: superagentQueue.makeQueue() } )`
 Specify an Array that will be used as a queue to chain multiple Superagent requests. Only one request will execute at a time. This is similar to what can be done with libraries such as [Q](https://github.com/kriskowal/q).
 
 ```js
@@ -62,7 +62,7 @@ const superagentQueue = require('superagent-d2l-queue');
 
 // ...
 
-const queue = [];
+const queue = superagentQueue.makeQueue();
 
 const first = request
     .get( ... )

--- a/README.md
+++ b/README.md
@@ -5,43 +5,107 @@
 [![Coverage Status][coverage-image]][coverage-url]
 [![Dependency Status][dependencies-image]][dependencies-url]
 
-Extends Superagent by adding the ability to queue up requests and retry failed requests due to timeouts.
+Extends [Superagent](https://github.com/visionmedia/superagent) by adding the ability to queue up requests and retry failed requests due to timeouts.
 
 ## Installation
 
 Install from NPM:
 
 ```shell
-npm install superagent-d2l-queue
+npm install superagent-d2l-queue --save
 ```
 
 ## Usage
 
-Added functions:
+### `superagentQueue(options)`
 
-`useQueue()`
+```js
+const request = require( 'superagent' );
+const superagentQueue = require('superagent-d2l-queue');
 
-Every request that has this specified will be queued up.
+// ...
 
-`retryOnConnectionFailure( handler )`
+request
+    .get( ... )
+    .use( superagentQueue( ... ) )
+    .end( function( err, res ) {
+        // ...
+    });
+```
+
+__Options (defaults):__
+
+All parameters are optional
+```js
+{
+    queue: undefined, // Array
+    initialTimeout: 2000,
+    backoff: {
+        exp: { // Exponential backoff
+            factor: 1.4 //  (1.4 ^ retryCount)
+        },
+        retries: 5, // Number of retries
+        override: function( retryCount ) { // Compute the time between each retry interval.
+            return Math.round( initialTimeout *
+                Math.pow( backoff.exp.factor, retryCount ) );
+        }
+    }
+}
+```
+
+### `superagentQueue( { queue: [...] } )`
+Specify an Array that will be used as a queue to chain multiple Superagent requests. Only one request will execute at a time. This is similar to what can be done with libraries such as [Q](https://github.com/kriskowal/q).
+
+```js
+const request = require( 'superagent' );
+const superagentQueue = require('superagent-d2l-queue');
+
+// ...
+
+const queue = [];
+
+const first = request
+    .get( ... )
+    .use( superagentQueue( { queue } ) )
+    .end( function( err, res ) {
+        // ...
+    });
+
+const second = request
+    .get( ... )
+    .use( superagentQueue( { queue } ) )
+    .end( function( err, res ) {
+        // ...
+    });
+
+const third = request
+    .get( ... )
+    .use( superagentQueue( { queue } ) )
+    .end( function( err, res ) {
+        // ...
+    });
+
+// etc...
+```
+
+### `retryOnConnectionFailure( handler )`
 
 When a request fails due to a timeout or connection failure the request will be retried every 2 seconds until it can successfully send the request. A handler function can be specified in order to complete some action whenever a timeout occurs. This handler is optional.
 
 ```js
-import Request from 'superagent';
-import 'superagent-d2l-queue';
+const request = require( 'superagent' );
+const superagentQueue = require('superagent-d2l-queue');
 
-Request
-	.get( '/me' )
-	.useQueue()
-	.retryOnConnectionFailure( function() {
-		//do something
-	})
-	.end( function( err,res ) {
-		//do something
-	});
+request
+    .get( ... )
+    .use( superagentQueue( ... ) )
+    .retryOnConnectionFailure( function() {
+        //do something
+    })
+    .end( function( err, res ) {
+        // ...
+    });
 ```
-
 
 [npm-url]: https://npmjs.org/package/superagent-d2l-queue
 [npm-image]: https://img.shields.io/npm/v/superagent-d2l-queue.png

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "superagent-d2l-queue",
   "description": "Request queue extension on superagent",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "lib/index.js",
   "scripts": {
     "prebuild": "npm run clean -s",
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/Brightspace/superagent-d2l-queue",
   "dependencies": {
-    "superagent": "1.2.0"
+    "superagent": "1.8.1"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",

--- a/src/RequestQueue.js
+++ b/src/RequestQueue.js
@@ -9,11 +9,11 @@ function requestQueue( params ) {
 		queue: undefined, // Array
 		initialTimeout: 2000,
 		backoff: {
-            exp: {
-                factor: 1.4
-            },
-            retries: 5,
-            override: _computeWaitPeriod
+			exp: {
+				factor: 1.4
+			},
+			retries: 5,
+			override: _computeWaitPeriod
 		}
 	}, params );
 
@@ -21,9 +21,9 @@ function requestQueue( params ) {
 
 	let retryCount = 0;
 
-    function _computeWaitPeriod( retryCount ) {
+	function _computeWaitPeriod( retryCount ) {
 		return Math.round( options.initialTimeout *
-            Math.pow( options.backoff.exp.factor, retryCount ) );
+			Math.pow( options.backoff.exp.factor, retryCount ) );
 	}
 
 	function _resetRequest( request, timeout ) {
@@ -136,8 +136,14 @@ function requestQueue( params ) {
 	return this;
 }
 
-module.exports = function(params) {
-  return function(request) {
-      return requestQueue.call(request, params);
-  };
+function create(params) {
+	return function(request) {
+		return requestQueue.call(request, params);
+	};
 };
+
+create.makeQueue = function() {
+	return [];
+};
+
+module.exports = create;

--- a/src/RequestQueue.js
+++ b/src/RequestQueue.js
@@ -1,25 +1,31 @@
 'use strict';
 
-import SuperAgent from 'superagent';
+const retry = require( './Retry' );
 
-function RequestQueue( superAgent ) {
+function requestQueue( params ) {
 
-	let Request = superAgent.Request;
-	let superAgentEnd = Request.prototype.end;
-	let queue = [];
+	const superagentEnd = this.end;
+	const options = Object.assign( {
+		queue: undefined, // Array
+		initialTimeout: 2000,
+		backoff: {
+            exp: {
+                factor: 1.4
+            },
+            retries: 5,
+            override: _computeWaitPeriod
+		}
+	}, params );
 
-	const TIMEOUT_REGEX = /timeout of \d+ms exceeded/;
-	const CORS_REGEX = /Origin is not allowed by Access-Control-Allow-Origin/;
+	this.queue = options.queue;
 
-	const EXP_FACTOR = 1.4;
-	const MAX_EXP_DROPOFF = 15;
-	const MAX_INITIAL_TIMEOUT_REPEAT = 5;
-
-	let initialRetryTimeout;
 	let retryCount = 0;
-	let repeatCount = 0;
 
-	//HACK to Reset request to allow retry
+    function _computeWaitPeriod( retryCount ) {
+		return Math.round( options.initialTimeout *
+            Math.pow( options.backoff.exp.factor, retryCount ) );
+	}
+
 	function _resetRequest( request, timeout ) {
 
 		let headers = {};
@@ -40,8 +46,7 @@ function RequestQueue( superAgent ) {
 		delete request.req;
 		delete request.xhr;
 
-		let headerKeys = Object.keys( headers );
-
+		const headerKeys = Object.keys( headers );
 		for( let i = 0; i < headerKeys.length; i++ ) {
 			request.set( headerKeys[i], headers[headerKeys[i]] );
 		}
@@ -59,119 +64,80 @@ function RequestQueue( superAgent ) {
 		}
 	}
 
-	function _shouldAttempRetry( err, retryEnabled ) {
-
-		if ( !retryEnabled || !err) {
-			return false;
-		}
-
-		let gatewayOrServiceUnavailable =
-				err.status && ( err.status === 502 || err.status === 503 || err.status === 504 );
-
-		let requestTimedOut = TIMEOUT_REGEX.test( err ) || err.code ==='ECONNABORTED';
-
-		if ( gatewayOrServiceUnavailable || requestTimedOut ) {
-			initialRetryTimeout = 2000;
-			return true;
-		}
-
-		let corsError = CORS_REGEX.test( err );
-
-		if ( corsError ) {
-			initialRetryTimeout = 5000;
-			return true;
-		}
-
-		return false;
-	}
-
 	function _sendNextRequest() {
 
-		let item = queue[0];
-
-		if ( !item) {
-			return;
+		const item = this.queue[0];
+		if ( item ) {
+			_sendRequest( item.request, item.fn, item.timeout );
 		}
 
-		_sendRequest( item.request, item.fn, item.timeout );
-	}
-
-	function _getTimeout( retryCount ) {
-		return Math.round( initialRetryTimeout * Math.pow( 1.5, retryCount ) );
 	}
 
 	function _sendRequest( request, fn, timeout ) {
 
-		superAgentEnd.call( request, ( err, res ) => {
+		superagentEnd.call( request, ( err, res ) => {
 
-			if ( _shouldAttempRetry( err, request.retryEnabled ) ) {
+			if ( request.retryEnabled && retry.should( err, res ) ) {
 
 				_handleConnectionError( request.connectionErrorHandler, err );
 
-				if ( repeatCount !== MAX_INITIAL_TIMEOUT_REPEAT ) {
-					repeatCount = repeatCount = repeatCount + 1;
-				}else if ( retryCount !== MAX_EXP_DROPOFF ) {
+				if ( retryCount !== options.backoff.retries ) {
 					retryCount = retryCount + 1;
 				}
 
-				let retryTimeout = _getTimeout( retryCount );
+				let retryWaitPeriod = options.backoff.override( retryCount );
 
 				setTimeout( function() {
 					_resetRequest( request, timeout );
 					_sendRequest( request, fn, request._timeout );
-				}, retryTimeout );
+				}, retryWaitPeriod );
+			} else {
+				retryCount = 0;
 
-				return;
+				_returnResponse( fn, err, res );
+
+				if ( request.queue ) {
+					request.queue.shift();
+					_sendNextRequest.call( request );
+				}
 			}
 
-			repeatCount = 0;
-			retryCount = 0;
-
-			_returnResponse( fn, err, res );
-
-			if ( request.queueRequest ) {
-				queue.shift();
-				_sendNextRequest();
-			}
 		});
 
 	}
 
-	Request.prototype.useQueue = function () {
-		this.queueRequest = true;
-		return this;
-	};
-
-	Request.prototype.retryOnConnectionFailure = function( connectionErrorHandler ) {
+	this.retryOnConnectionFailure = function( connectionErrorHandler ) {
 		this.retryEnabled = true;
 		this.connectionErrorHandler = connectionErrorHandler;
 		return this;
 	};
 
-	Request.prototype.end = function( fn ) {
+	this.end = function( fn ) {
 
-		let self = this;
-		let queueRequest = self.queueRequest;
+		if ( this.queue ) {
 
-		if ( queueRequest ) {
-
-			queue.push(
+			this.queue.push(
 				{
-					request: self,
+					request: this,
 					fn: fn,
-					timeout: self._timeout
+					timeout: this._timeout
 				}
 			);
 
-			if ( queue.length === 1 ) {
-				_sendNextRequest();
+			if ( this.queue.length === 1 ) {
+				_sendNextRequest.call(this);
 			}
-
-			return;
+		} else {
+			_sendRequest( this, fn, this._timeout );
 		}
 
-		_sendRequest( self, fn, self._timeout );
 	};
+
+	return this;
 }
 
-export default RequestQueue( SuperAgent );
+module.exports = function(params) {
+  return function(request) {
+      return requestQueue.call(request, params);
+  };
+};

--- a/src/Retry.js
+++ b/src/Retry.js
@@ -1,0 +1,58 @@
+/*
+ * Based on 'superagent-retry'
+ * https://github.com/segmentio/superagent-retry/blob/master/lib/retries.js
+ */
+
+function econnreset( err, res ) {
+	return err && err.code === 'ECONNRESET';
+}
+
+function etimedout( err, res ) {
+	return err && err.code === 'ETIMEDOUT';
+}
+
+function eaddrinfo( err, res ) {
+	return err && err.code === 'EADDRINFO';
+}
+
+function esockettimedout( err, res ) {
+	return err && err.code === 'ESOCKETTIMEDOUT';
+}
+
+function internal( err, res ) {
+	return res && res.status === 500;
+}
+
+function gateway( err, res ) {
+	return res && [502, 503, 504].indexOf( res.status) !== -1;
+}
+
+function timeout( err, res ) {
+	return err && /^timeout of \d+ms exceeded$/.test( err.message);
+}
+
+function cors( err, res ) {
+	return err && /Origin is not allowed by Access-Control-Allow-Origin/.test( err.message);
+}
+
+const retryChecks = [
+	econnreset,
+	etimedout,
+	eaddrinfo,
+	esockettimedout,
+	gateway,
+	timeout,
+	internal,
+	cors
+];
+
+function should( err, res ) {
+	return retryChecks.some( function ( check ) {
+		return check(err, res);
+	} );
+}
+
+module.exports = {
+	should,
+	retryChecks
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
 'use strict';
 
 module.exports = require( './RequestQueue' );
-
-

--- a/test/RequestQueueTests.js
+++ b/test/RequestQueueTests.js
@@ -118,7 +118,7 @@ describe( 'RequestQueue', function() {
 
 			var concurrencyChecker = getConcurrencyChecker( 1 );
 
-			const queue = [];
+			const queue = superagentQueue.makeQueue();
 			superagent
 				.get( 'http://localhost:5000/successWithDelay' )
 				.use( superagentQueue( { queue } ) )
@@ -170,7 +170,7 @@ describe( 'RequestQueue', function() {
 		it( 'use queue and 404 response, expect 4 failures', function( done ) {
 
 			var failureCount = 0;
-			const queue = [];
+			const queue = superagentQueue.makeQueue();
 
 			superagent
 				.get( 'http://localhost:5000/faiure' )


### PR DESCRIPTION
Added:
- Ability to override retries
- Ability to have multiple queues in the same file (by specifying queue)
- Retry mechanisms from superagent-retry (covers additional states
  such as status 500, etc.)
- Ability to override back-off computation

Changed:
- Use Superagent plugin system
- initialTimeout was set to 5000 on "cors" failures. Not sure
  why it was different from other timeouts?
- Tests now require at least node 4.x to execute. Node 10.x is
  too old and we shouldn't bother supporting it

Fixed:
- Removed repeatCount as it was not being used
- Works with Superagent >1.2.0

Will add in future commit:
- Ability to override defaults for superagent instance
  (rather than per request)
- Ability to specify/add/remove retry checks on
  superagent/request level
